### PR TITLE
Add type hints to the project

### DIFF
--- a/images/_img.py
+++ b/images/_img.py
@@ -1,6 +1,6 @@
 from joy import *
 
-def render(*shapes):
+def render(*shapes: Shape) -> None:
     """Renders the shapes as svg and prints them.
     """
     bg = Group([
@@ -9,7 +9,7 @@ def render(*shapes):
         Line(start=Point(y=-150, x=0), end=Point(y=150, x=0), stroke="#ddd"),
     ])
 
-    shape = Group(
+    shape: Shape = Group(
         [bg, *shapes],
         stroke_width=2 # increase the stroke-width to compensate for scaling
     )

--- a/images/donut.py
+++ b/images/donut.py
@@ -1,7 +1,7 @@
 from joy import *
 from _img import render
 
-def donut(x, y, r):
+def donut(x: float, y: float, r: float) -> Shape:
     c1 = Circle(center=Point(x=x, y=y), radius=r)
     c2 = Circle(center=Point(x=x, y=y), radius=r/2)
     return c1+c2

--- a/joy.py
+++ b/joy.py
@@ -98,7 +98,7 @@ represented as SVG image by jupyter.
 import html
 import itertools
 import random as random_module
-from typing import Any, Dict, Generator, List, Optional, Sequence, Union
+from typing import Any, Dict, Generator, List, Optional, Sequence, Union, TypeVar
 
 __version__ = "0.2.3"
 __author__ = "Anand Chitipothu <anand@fossunited.org>"
@@ -111,6 +111,7 @@ def shape_sequence() -> Generator[str, None, None]:
 shape_seq = shape_sequence()
 
 Attr = Union[str, float]
+S = TypeVar('S', bound='Shape')
 
 class Shape:
     """Shape is the base class for all shapes in Joy.
@@ -147,7 +148,7 @@ class Shape:
         else:
             raise AttributeError(name)
 
-    def apply_transform(self, transform: Optional['Transformation']) -> 'Shape':
+    def apply_transform(self: S, transform: Optional['Transformation']) -> S:
         if self.transform is not None:
             transform = self.transform | transform
 
@@ -155,8 +156,8 @@ class Shape:
         shape.transform = transform
         return shape
 
-    def clone(self) -> 'Shape':
-        shape: Shape = object.__new__(self.__class__)
+    def clone(self: S) -> S:
+        shape: S = object.__new__(self.__class__)
         shape.__dict__.update(self.__dict__)
         return shape
 
@@ -529,7 +530,7 @@ def render_tag(tag: str, close: bool = False, **attrs: Attr) -> str:
         return f"<{tag}{end}"
 
 class Transformation:
-    def apply(self, shape: Shape) -> 'Shape':
+    def apply(self, shape: Shape) -> Shape:
         return shape.apply_transform(self)
 
     def join(self, transformation: 'Transformation') -> 'TransformationList':

--- a/joy.py
+++ b/joy.py
@@ -792,7 +792,7 @@ def show(*shapes: Shape) -> None:
     shapes_list = markers + list(shapes)
     img = SVG(shapes_list)
 
-    from IPython.display import display
+    from IPython.display import display  # type: ignore
     display(img)
 
 def circle(x: float = 0, y: float = 0, r: float = 100, **kwargs: Attr) -> Circle:

--- a/joy.py
+++ b/joy.py
@@ -133,10 +133,13 @@ class Shape:
 
 
     def get_reference(self) -> 'Shape':
-        if not "id" in self.attrs:
-            self.attrs["id"] = next(shape_seq)
+        if "id" not in self.attrs:
+            shape_id = next(shape_seq)
+            self.attrs["id"] = shape_id
+        else:
+            shape_id = str(self.attrs["id"])
 
-        attrs = {"xlink:href": "#" + str(self.id)}
+        attrs = {"xlink:href": "#" + shape_id}
         return Shape("use", **attrs)
 
     def __repr__(self) -> str:

--- a/tests/test_joy.py
+++ b/tests/test_joy.py
@@ -8,26 +8,27 @@ from joy import (
     render_tag,
     Point,
     Translate,  Rotate)
+from typing import Dict, List
 import pytest
 import re
 import yaml
 from pathlib import Path
 
-def test_render_tag():
+def test_render_tag() -> None:
     assert render_tag("circle") == "<circle>"
     assert render_tag("circle", cx=0, cy=0, r=10) == '<circle cx="0" cy="0" r="10">'
     assert render_tag("circle", cx=0, cy=0, r=10, close=True) == '<circle cx="0" cy="0" r="10" />'
     assert render_tag("circle", fill='text "with" quotes') == '<circle fill="text &quot;with&quot; quotes">'
 
-def test_rotate():
+def test_rotate() -> None:
     assert Rotate(angle=45).as_str() == "rotate(45)"
     assert Rotate(angle=45, anchor=Point(10, 20)).as_str() == "rotate(45 10 20)"
 
-def test_translate():
+def test_translate() -> None:
     assert Translate(x=10, y=20).as_str() == "translate(10 20)"
 
-def read_tests_files():
-    tests = []
+def read_tests_files() -> List[Dict[str, str]]:
+    tests: List[Dict[str, str]] = []
     p = Path(__file__).parent
     files = p.rglob('*.yml')
     for f in files:
@@ -41,11 +42,11 @@ testdata = read_tests_files()
 test_ids = [t['name'] for t in testdata]
 
 @pytest.mark.parametrize('testspec', testdata, ids=test_ids)
-def test_shapes(testspec):
+def test_shapes(testspec: Dict[str, str]) -> None:
     code = testspec['code']
     expected = testspec['expected']
 
-    env = {}
+    env: Dict[str, object] = {}
     exec("from joy import *", env, env)
     node = eval(code, env)
 
@@ -56,5 +57,5 @@ def test_shapes(testspec):
 
     assert expected == svg
 
-def normalize_space(text):
+def normalize_space(text: str) -> str:
     return re.sub("\s+", " ", text).strip()


### PR DESCRIPTION
This adds static type hints to the project. These hints don't affect anything at runtime, but they allow type checkers, analysis tools and IDEs to provide type checks while writing code, catching bugs early.

See [PEP 484](https://python.org/dev/peps/pep-0008) for more information.

## Rationale

There's a few really nice benefits to having these type hints:

### Type inference and autocompletion:
- Without types:

  ![image](https://user-images.githubusercontent.com/43412083/131658254-909e7bae-db88-4039-9520-8b0e73388bb3.png)
  ![image](https://user-images.githubusercontent.com/43412083/131658361-ffe3c575-a228-4e86-9d0e-8d96ced2c189.png)

- With types:

  ![image](https://user-images.githubusercontent.com/43412083/131658587-7bb6d954-0558-45b4-8818-436ac5ee86f7.png)
  ![image](https://user-images.githubusercontent.com/43412083/131658613-2abe4035-92c3-4228-9a2b-098a26bd44f8.png)

### Better bug tracking:

Adding types led me to find a few bugs and edge cases in the codebase. Such as:

- `render_tag` and `**kwargs`:

  Currently,
  ```python
  render_tag('svg', **{'close': True})
  ```
  behaves the same way as 
  ```python
  render_tag('svg', close=True)
  ```
  Ideally `close` should never be accessed from the `kwargs`, as `kwargs` are supposed to purely be svg attributes.

  To fix this, we can change the type signature of `render_svg` to make `close` a positional-only argument:
  ```python
  def render_tag(tag: str, close: bool = False, /, **attrs: Attr) -> str:
  #                                             ^ this is the addition
  ```
  However this change will require the user to be using Python 3.8 or above. Do let me know what you think about that.

- A similar issue existed in `Shape.__init__`, where the `children` and `transform` properties could be inserted through kwargs.

## Scope for improvement

This patch has a few areas that can be improved, specifically regarding generics.

Right now, `circle().clone()` is correctly identified as `Circle` type, but doing transformations such as `circle() | scale(2)`, it loses its specificity and becomes `Shape`.

A bit more type information can be added to the subclasses of `Transformation`, which can tell what the new type of the shape will be after transformation. I'd be happy to add that in as well.

---

I mainly did this patch for myself, to help better understand the project. If this seems useful, you could incorporate this into the main project as well. Any thoughts / suggestions would be appreciated :)